### PR TITLE
Add ExceptionManager and remove ErrorHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ export const providers = [
 ]
 ```
 
+Finally, within the app exception handler you can use `Relay/ExceptionManager` to convert Exceptions to api response objects.
+
+```ts
+const ExceptionManager = use<Relay.ExceptionManager>('Relay/ExceptionManager')
+
+class ExceptionHandler {
+  async handle (error, { response }: AdonisJs.Context) {
+    const { status, errors } = ExceptionManager.toResponse(error)
+    response.status(status).send({ errors })
+  }
+}
+```
+
 That's all from the usage point of view. The validation errors gets a unique set of error codes, which are shared by all micro service and you won't have to do much on that front.
 
 ## Defining codes for exceptions

--- a/index.ts
+++ b/index.ts
@@ -7,4 +7,4 @@
  * file that was distributed with this source code.
  */
 
-export { ErrorsConfig, JSONAPIErrorNode, ErrorHandlerContract } from './src/Contracts'
+export { ErrorsConfig, JSONAPIErrorNode, ExceptionManagerContract } from './src/Contracts'

--- a/package.json
+++ b/package.json
@@ -60,7 +60,5 @@
     "commit-msg": "node ./node_modules/@adonisjs/mrm-preset/validateCommit/conventional/validate.js",
     "pre-commit": "doctoc README.md --title='## Table of contents' && git add README.md"
   },
-  "dependencies": {
-    "youch": "^2.0.10"
-  }
+  "dependencies": {}
 }

--- a/providers/ErrorHandlerProvider.ts
+++ b/providers/ErrorHandlerProvider.ts
@@ -7,10 +7,11 @@
  * file that was distributed with this source code.
  */
 
-import { ErrorHandler } from '../src/ErrorHandler'
+import { ExceptionManager } from '../src/ExceptionManager'
+import { ErrorFormatter } from '../src/ErrorFormatter'
 
 export default class ErrorHandlerProvider {
-  constructor (public container) {}
+  constructor (protected container) {}
 
   /**
    * Register `Relay/ErrorHandler` to the container. We don't
@@ -20,19 +21,12 @@ export default class ErrorHandlerProvider {
   public register () {
     this.container.singleton('Relay/ErrorHandler', () => {
       const Config = this.container.use('Adonis/Src/Config')
-      const Logger = this.container.use('Adonis/Src/Logger')
-      return new ErrorHandler(Config.get('errorCodes'), Logger)
+      return new ExceptionManager(Config.get('errorCodes'))
     })
   }
 
   public async boot () {
     const handler = this.container.use('Relay/ErrorHandler')
-    const Server = this.container.use('Adonis/Src/Server')
-
-    /**
-     * Handle exceptions
-     */
-    Server.onError(handler.handleException.bind(handler))
 
     /**
      * Parse config and report errors (if any)
@@ -48,7 +42,7 @@ export default class ErrorHandlerProvider {
       /**
        * Define custom formatter
        */
-      configure({ formatter: handler.getFormatter() })
+      configure({ formatter: ErrorFormatter })
     } catch (error) {
       // Indicative isn't installed, so ignore the error
     }

--- a/providers/ErrorHandlerProvider.ts
+++ b/providers/ErrorHandlerProvider.ts
@@ -14,19 +14,19 @@ export default class ErrorHandlerProvider {
   constructor (protected container) {}
 
   /**
-   * Register `Relay/ErrorHandler` to the container. We don't
+   * Register `Relay/ExceptionManager` to the container. We don't
    * need a new instance for handler everytime, so binding
    * a singleton is the way to go
    */
   public register () {
-    this.container.singleton('Relay/ErrorHandler', () => {
+    this.container.singleton('Relay/ExceptionManager', () => {
       const Config = this.container.use('Adonis/Src/Config')
       return new ExceptionManager(Config.get('errorCodes'))
     })
   }
 
   public async boot () {
-    const handler = this.container.use('Relay/ErrorHandler')
+    const handler = this.container.use('Relay/ExceptionManager')
 
     /**
      * Parse config and report errors (if any)

--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -36,9 +36,8 @@ export type JSONAPIErrorNode = {
   },
 }
 
-export interface ErrorHandlerContract {
+export interface ExceptionManagerContract {
   parse (): void,
-  exceptions <T extends keyof any> (): { [K in T]: K },
-  getErrors (error: any): { status: number, errors: JSONAPIErrorNode[] },
-  handleException (error: any, { response }): Promise<void>,
+  refs <T extends keyof any> (): { [K in T]: K },
+  toResponse (error: any): { status: number, errors: JSONAPIErrorNode[] },
 }

--- a/test/exception-handler.spec.ts
+++ b/test/exception-handler.spec.ts
@@ -8,15 +8,7 @@
  */
 
 import * as test from 'japa'
-import { ErrorHandler } from '../src/ErrorHandler'
-
-const fakeLogger = {
-  fatal () {},
-}
-
-const request = {
-  request: {},
-}
+import { ExceptionManager } from '../src/ExceptionManager'
 
 test.group('ExceptionHandler', () => {
   test('build error object from config', async (assert) => {
@@ -37,28 +29,13 @@ test.group('ExceptionHandler', () => {
       codesBucket: 10000,
     }
 
-    const response = {
-      _state: {},
-      status (code) {
-        this._state.code = code
-        return this
-      },
-      send (body) {
-        this._state.body = body
-      },
-    }
-
-    const handler = new ErrorHandler(config, fakeLogger)
-    await handler.handleException(error, { request, response })
-
-    assert.deepEqual(response._state, {
-      code: 500,
-      body: {
-        errors: [{
-          title: 'Your account is not in active state',
-          code: 10001,
-        }],
-      },
+    const handler = new ExceptionManager(config)
+    assert.deepEqual(handler.toResponse(error), {
+      status: 500,
+      errors: [{
+        title: 'Your account is not in active state',
+        code: 10001,
+      }],
     })
   })
 
@@ -81,28 +58,14 @@ test.group('ExceptionHandler', () => {
       codesBucket: 10000,
     }
 
-    const response = {
-      _state: {},
-      status (code) {
-        this._state.code = code
-        return this
-      },
-      send (body) {
-        this._state.body = body
-      },
-    }
+    const handler = new ExceptionManager(config)
 
-    const handler = new ErrorHandler(config, fakeLogger)
-    await handler.handleException(error, { request, response })
-
-    assert.deepEqual(response._state, {
-      code: 400,
-      body: {
-        errors: [{
-          title: 'Your account is not in active state',
-          code: 10001,
-        }],
-      },
+    assert.deepEqual(handler.toResponse(error), {
+      status: 400,
+      errors: [{
+        title: 'Your account is not in active state',
+        code: 10001,
+      }],
     })
   })
 
@@ -121,28 +84,13 @@ test.group('ExceptionHandler', () => {
       codesBucket: 10000,
     }
 
-    const response = {
-      _state: {},
-      status (code) {
-        this._state.code = code
-        return this
-      },
-      send (body) {
-        this._state.body = body
-      },
-    }
-
-    const handler = new ErrorHandler(config, fakeLogger)
-    await handler.handleException(error, { request, response })
-
-    assert.deepEqual(response._state, {
-      code: 400,
-      body: {
-        errors: [{
-          title: 'Unable to process request',
-          code: 1000,
-        }],
-      },
+    const handler = new ExceptionManager(config)
+    assert.deepEqual(handler.toResponse(error), {
+      status: 400,
+      errors: [{
+        title: 'Unable to process request',
+        code: 1000,
+      }],
     })
   })
 })

--- a/test/parse-config.spec.ts
+++ b/test/parse-config.spec.ts
@@ -8,9 +8,7 @@
  */
 
 import * as test from 'japa'
-import { ErrorHandler } from '../src/ErrorHandler'
-
-const fakeLogger = {}
+import { ExceptionManager } from '../src/ExceptionManager'
 
 test.group('Exception Parser', () => {
   test('raise error when errorCode referenced by an exception doesn\'t exists', (assert) => {
@@ -22,7 +20,7 @@ test.group('Exception Parser', () => {
       codesBucket: 1000,
     }
 
-    const handler = new ErrorHandler(config, fakeLogger)
+    const handler = new ExceptionManager(config)
     const fn = () => handler.parse()
     assert.throw(fn, 'Error code 10001 used by ERR_MISSING_FILE doesn\'t exists in list of errorCodes')
   })
@@ -39,7 +37,7 @@ test.group('Exception Parser', () => {
       codesBucket: 1000,
     }
 
-    const handler = new ErrorHandler(config, fakeLogger)
+    const handler = new ExceptionManager(config)
     const fn = () => handler.parse()
     assert.throw(fn, 'Error code 11 must be over codesBucket range of 1000')
   })
@@ -56,7 +54,7 @@ test.group('Exception Parser', () => {
       codesBucket: 1000,
     }
 
-    const handler = new ErrorHandler(config, fakeLogger)
+    const handler = new ExceptionManager(config)
     const fn = () => handler.parse()
     assert.throw(fn, 'Error code 2100 must be under codesBucket range of 2000')
   })
@@ -71,7 +69,7 @@ test.group('Exception Parser', () => {
       codesBucket: 1000,
     }
 
-    const handler = new ErrorHandler(config as any, fakeLogger)
+    const handler = new ExceptionManager(config as any)
     const fn = () => handler.parse()
     assert.throw(fn, 'Each error code inside config/errorCodes.ts must have a message')
   })
@@ -88,7 +86,7 @@ test.group('Exception Parser', () => {
       codesBucket: 1000,
     }
 
-    const handler = new ErrorHandler(config, fakeLogger)
+    const handler = new ExceptionManager(config)
     const fn = () => handler.parse()
     assert.throw(fn, 'Error code 1001 used by required rule doesn\'t exists in list of errorCodes')
   })


### PR DESCRIPTION
Now, since AdonisJs has support for app exception handler, we remove the `Relay/ErrorHandler` in favor of same.

The `ExceptionManager` now offers a transparent API to convert `Exception` objects to API response. 